### PR TITLE
removed autostart from 3d model preview

### DIFF
--- a/src/pages/product/product-detail.ts
+++ b/src/pages/product/product-detail.ts
@@ -37,7 +37,7 @@ export class ProductDetailPage {
   }
 
   getSafeUrl() {
-    this.safeUrl = this.sanitizer.bypassSecurityTrustResourceUrl('https://sketchfab.com/models/' + this.product.modelPath + '/embed?autostart=1');
+    this.safeUrl = this.sanitizer.bypassSecurityTrustResourceUrl('https://sketchfab.com/models/' + this.product.modelPath + '/embed');
     return this.safeUrl;
   }
 


### PR DESCRIPTION
Disabled autoloading of 3d models - would make the page refresh constantly if the 3d model was halfway in view
